### PR TITLE
Clearing timeout on unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,10 @@ class Ripples extends PureComponent {
     rippleStyle: {},
   }
 
+  componentWillUnmount() {
+    clearTimeout(this.state.timeoutId);
+  }
+
   handleClick = (ev) => {
     if (ev.stopPropagation) {
       ev.stopPropagation()
@@ -56,7 +60,7 @@ class Ripples extends PureComponent {
       }
     })
 
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       const size = Math.max(offsetWidth, offsetHeight)
 
       this.setState({
@@ -69,6 +73,8 @@ class Ripples extends PureComponent {
         }
       })
     }, 50)
+
+    this.setState({ timeoutId });
 
     if (typeof onClick === 'function') {
       onClick(ev)

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ class Ripples extends PureComponent {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.state.timeoutId);
+    clearTimeout(this.timeoutId);
   }
 
   handleClick = (ev) => {
@@ -74,7 +74,7 @@ class Ripples extends PureComponent {
       })
     }, 50)
 
-    this.setState({ timeoutId });
+    this.timeoutId = timeoutId;
 
     if (typeof onClick === 'function') {
       onClick(ev)


### PR DESCRIPTION
This fixes a warning that happens when calling setState on an unmounted component.  The cause is setTimeout will still run after the component was unmounted.

Ran into this when working on a wizard where you got onto the next step before the ripple can finish animating.  